### PR TITLE
[wespeaker] Refine wespeaker codes.

### DIFF
--- a/examples/voxceleb/v2/conf/ecapa_tdnn.yaml
+++ b/examples/voxceleb/v2/conf/ecapa_tdnn.yaml
@@ -1,11 +1,11 @@
 ### train configuraton
 
-exp_dir: exp/ECAPA_TDNN_GLOB_c512-ASTP-emb192-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch66
+exp_dir: exp/ECAPA_TDNN_GLOB_c512-ASTP-emb192-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch150
 gpus: "[0,1]"
 num_avg: 10
 
 seed: 42
-num_epochs: 66
+num_epochs: 150
 save_epoch_interval: 5 # save model every 5 epochs
 log_batch_interval: 100 # log every 100 batchs
 
@@ -40,6 +40,7 @@ projection_args:
   scale: 32.0
   easy_margin: False
 
+margin_scheduler: MarginScheduler
 margin_update:
   initial_margin: 0.0
   final_margin: 0.2

--- a/examples/voxceleb/v2/conf/resnet.yaml
+++ b/examples/voxceleb/v2/conf/resnet.yaml
@@ -1,11 +1,11 @@
 ### train configuraton
 
-exp_dir: exp/ResNet34-TSTP-emb256-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch66
+exp_dir: exp/ResNet34-TSTP-emb256-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch150
 gpus: "[0,1]"
 num_avg: 10
 
 seed: 42
-num_epochs: 66
+num_epochs: 150
 save_epoch_interval: 5 # save model every 5 epochs
 log_batch_interval: 100 # log every 100 batchs
 
@@ -40,6 +40,7 @@ projection_args:
   scale: 32.0
   easy_margin: False
 
+margin_scheduler: MarginScheduler
 margin_update:
   initial_margin: 0.0
   final_margin: 0.2

--- a/examples/voxceleb/v2/conf/xvec.yaml
+++ b/examples/voxceleb/v2/conf/xvec.yaml
@@ -1,11 +1,11 @@
 ### train configuraton
 
-exp_dir: exp/XVEC-TSTP-emb512-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch66
+exp_dir: exp/XVEC-TSTP-emb512-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch150
 gpus: "[0,1]"
 num_avg: 10
 
 seed: 42
-num_epochs: 66
+num_epochs: 150
 save_epoch_interval: 5 # save model every 5 epochs
 log_batch_interval: 100 # log every 100 batchs
 
@@ -40,6 +40,7 @@ projection_args:
   scale: 32.0
   easy_margin: False
 
+margin_scheduler: MarginScheduler
 margin_update:
   initial_margin: 0.0
   final_margin: 0.2

--- a/examples/voxceleb/v2/run.sh
+++ b/examples/voxceleb/v2/run.sh
@@ -8,7 +8,7 @@ stage=-1
 stop_stage=-1
 
 config=conf/ecapa_tdnn.yaml
-exp_dir=exp/ECAPA_TDNN_GLOB_c512-ASTP-emb192-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch66
+exp_dir=exp/ECAPA_TDNN_GLOB_c512-ASTP-emb192-fbank80-num_frms200-vox2_dev-aug0.6-spTrue-saFalse-ArcMargin-SGD-epoch150
 gpus="[0,1]"
 num_avg=10
 


### PR DESCRIPTION
1. Add "margin_scheduler" variable in config.yaml
2. Remove "add num_epochs according to aug_prob" in wespeaker/bin/train.py
3. Do not initialize the projection layer for model_init