### PR TITLE
remove ort version on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ lmdb==1.3.0
 onnxruntime
 soundfile==0.10.3.post1
 pypeln==0.4.9
-torchaudio

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ h5py
 pycodestyle==2.6.0
 pyflakes==2.2.0
 lmdb==1.3.0
-onnxruntime==1.11.1
+onnxruntime
 soundfile==0.10.3.post1
 pypeln==0.4.9
+torchaudio


### PR DESCRIPTION
I am new to wespeaker and thanks in advance for your work!

When I was configuring the environment, I found for CN-Celeb, torchaudio is essential for data preparation, so I would like to add it in requirements.txt.

Also, the current version of onnxruntime cannot be found in conda, so I remove the version specification.