### PR TITLE
[runtime] update onnxruntime benchmark results and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ pip3 install wespeakerruntime
 
 ## 🔥 News
 
+* 2023.02.27: Update onnxruntime (C++), see [onnxruntime](https://github.com/wenet-e2e/wespeaker/tree/master/runtime/onnxruntime), [#135](https://github.com/wenet-e2e/wespeaker/pull/135)
+
 * 2023.02.15: Update the code for multi-node training. For how to setup multi-node training, please refer to [#131](https://github.com/wenet-e2e/wespeaker/pull/131).
 * 2022.11.30: Multi-Query Multi-Head Attentive Pooling (MQMHASTP) and Intertopk-Subcenter Loss are supported, see [#115](https://github.com/wenet-e2e/wespeaker/pull/115).
-* 2022.11.22:
-    * We support Automatic Mixed Precision (AMP) training now, see [#103](https://github.com/wenet-e2e/wespeaker/pull/103).
-    * RepVGG is supported, see [#102](https://github.com/wenet-e2e/wespeaker/pull/102).
 
 ## Recipes
 

--- a/runtime/core/speaker/e2e_speaker.cc
+++ b/runtime/core/speaker/e2e_speaker.cc
@@ -29,6 +29,8 @@ E2eSpeaker::E2eSpeaker(const std::string& model_path,
                        const int sample_rate,
                        const int embedding_size,
                        const int SamplesPerChunk) {
+  // NOTE(cdliang): default num_threads = 1
+  const int kNumGemmThreads = 1;
   LOG(INFO) << "Reading model " << model_path;
   embedding_size_ = embedding_size;
   LOG(INFO) << "Embedding size: " << embedding_size_;
@@ -40,6 +42,7 @@ E2eSpeaker::E2eSpeaker(const std::string& model_path,
     std::make_shared<wenet::FeaturePipeline>(*feature_config_);
   feature_pipeline_->Reset();
 #ifdef USE_ONNX
+  OnnxSpeakerModel::InitEngineThreads(kNumGemmThreads);
   model_ = std::make_shared<OnnxSpeakerModel>(model_path);
 #endif
 }
@@ -128,7 +131,6 @@ void E2eSpeaker::ExtractEmbedding(const int16_t* data, int data_size,
     (*avg_emb)[i] /= chunk_num;
   }
 }
-
 
 float E2eSpeaker::CosineSimilarity(const std::vector<float>& emb1,
                                   const std::vector<float>& emb2) {

--- a/runtime/core/speaker/onnx_speaker_model.cc
+++ b/runtime/core/speaker/onnx_speaker_model.cc
@@ -21,18 +21,37 @@
 
 namespace wespeaker {
 
+Ort::Env OnnxSpeakerModel::env_ = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "OnnxModel");
+Ort::SessionOptions OnnxSpeakerModel::session_options_ = Ort::SessionOptions();
+
+void OnnxSpeakerModel::InitEngineThreads(int num_threads) {
+  session_options_.SetIntraOpNumThreads(num_threads);
+}
+
 OnnxSpeakerModel::OnnxSpeakerModel(const std::string& model_path) {
-  Ort::Env env_ = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "OnnxModel");
-  Ort::SessionOptions session_options_ = Ort::SessionOptions();
-  session_options_.SetIntraOpNumThreads(1);
   session_options_.SetGraphOptimizationLevel(
       GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
   // 1. Load sessions
   speaker_session_ = std::make_shared<Ort::Session>(env_, model_path.c_str(),
                                                       session_options_);
   // 2. Model info
-  input_names_ = {"feats"};
-  output_names_ = {"embs"};
+  Ort::AllocatorWithDefaultOptions allocator;
+  // 2.1. input info
+  int num_nodes = speaker_session_->GetInputCount();
+  // NOTE(cdliang): for speaker model, num_nodes is 1.
+  CHECK_EQ(num_nodes, 1);
+  input_names_.resize(num_nodes);
+  char* name = speaker_session_->GetInputName(0, allocator);
+  input_names_[0] = name;
+  LOG(INFO) << "Ouput name: " << name;
+
+  // 2.2. output info
+  num_nodes = speaker_session_->GetOutputCount();
+  CHECK_EQ(num_nodes, 1);
+  output_names_.resize(num_nodes);
+  name = speaker_session_->GetOutputName(0, allocator);
+  output_names_[0] = name;
+  LOG(INFO) << "Output name: " << name; 
 }
 
 void OnnxSpeakerModel::ExtractEmbedding(

--- a/runtime/core/speaker/onnx_speaker_model.cc
+++ b/runtime/core/speaker/onnx_speaker_model.cc
@@ -21,7 +21,8 @@
 
 namespace wespeaker {
 
-Ort::Env OnnxSpeakerModel::env_ = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "OnnxModel");
+Ort::Env OnnxSpeakerModel::env_ = Ort::Env(
+  ORT_LOGGING_LEVEL_WARNING, "OnnxModel");
 Ort::SessionOptions OnnxSpeakerModel::session_options_ = Ort::SessionOptions();
 
 void OnnxSpeakerModel::InitEngineThreads(int num_threads) {
@@ -51,7 +52,7 @@ OnnxSpeakerModel::OnnxSpeakerModel(const std::string& model_path) {
   output_names_.resize(num_nodes);
   name = speaker_session_->GetOutputName(0, allocator);
   output_names_[0] = name;
-  LOG(INFO) << "Output name: " << name; 
+  LOG(INFO) << "Output name: " << name;
 }
 
 void OnnxSpeakerModel::ExtractEmbedding(

--- a/runtime/core/speaker/onnx_speaker_model.h
+++ b/runtime/core/speaker/onnx_speaker_model.h
@@ -27,6 +27,8 @@ namespace wespeaker {
 
 class OnnxSpeakerModel : public SpeakerModel {
  public:
+  static void InitEngineThreads(int num_threads = 1);
+ public:
   explicit OnnxSpeakerModel(const std::string& model_path);
 
   void ExtractEmbedding(const std::vector<std::vector<float>>& feats,

--- a/runtime/onnxruntime/README.md
+++ b/runtime/onnxruntime/README.md
@@ -13,7 +13,7 @@ python wespeaker/bin/export_onnx.py \
 # When it finishes, you can find `final.onnx`.
 ```
 
-* Step 2. Build. The build requires cmake 3.14 or above.
+* Step 2. Build. The build requires cmake 3.14 or above, and gcc/g++ 5.4 or above.
 
 ``` sh
 mkdir build && cd build
@@ -33,7 +33,14 @@ embed_out=your_embedding_txt
   --wav_list $wav_scp \
   --result $embed_out \
   --speaker_model_path $onnx_dir/final.onnx
+  --SamplesPerChunk  80000  # 5s
+
 ```
+
+> NOTE: SamplesPerChunk: samples of one chunk. SamplesPerChunk = sample_rate * duration
+>
+> If SamplesPerChunk = -1, compute the embedding of whole sentence;
+> else compute embedding with chunk by chunk, and then average embeddings of chunk.
 
 2. Calculate the similarity of two speech.
 ```sh
@@ -46,3 +53,24 @@ onnx_dir=your_model_dir
     --threshold 0.5 \
     --speaker_model_path $onnx_dir/final.onnx
 ```
+
+## Benchmark
+1. RTF
+> set num_threads = 1
+>
+> CPU: Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz
+
+| Model              | RTF       |
+| ------------------ | --------- |
+| ResNet-34          | 0.060735  |
+| ECAPA-TDNN (C=512) | 0.0183512 |
+
+2. EER (%)
+> onnxruntime: SamplesPerChunk=-1.
+>
+> don't use mean normalization for evaluation embeddings.
+
+| Model          | vox-O | vox-E | vox-H |
+| -------------- | ----- | ----- | ----- |
+| ResNet-34-pt   | 0.814 | 0.933 | 1.679 |
+| ResNet-34-onnx | 0.814 | 0.933 | 1.679 |

--- a/runtime/onnxruntime/README.md
+++ b/runtime/onnxruntime/README.md
@@ -56,7 +56,9 @@ onnx_dir=your_model_dir
 
 ## Benchmark
 1. RTF
-> set num_threads = 1
+> num_threads = 1
+>
+> SamplesPerChunk = 80000
 >
 > CPU: Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz
 


### PR DESCRIPTION
## Benchmark
1. RTF
> num_threads = 1
>
> SamplesPerChunk = 80000
>
> CPU: Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz

| Model              | RTF       |
| ------------------ | --------- |
| ResNet-34          | 0.060735  |
| ECAPA-TDNN (C=512) | 0.0183512 |

2. EER (%)
> onnxruntime: SamplesPerChunk=-1.
>
> don't use mean normalization for evaluation embeddings.

| Model          | vox-O | vox-E | vox-H |
| -------------- | ----- | ----- | ----- |
| ResNet-34-pt   | 0.814 | 0.933 | 1.679 |
| ResNet-34-onnx | 0.814 | 0.933 | 1.679 |