### PR TITLE
fix a bug in executor.py

### DIFF
--- a/wespeaker/utils/executor.py
+++ b/wespeaker/utils/executor.py
@@ -47,7 +47,7 @@ def run_epoch(dataloader,
     with torch.set_grad_enabled(True), model_context():
         for i, batch in enumerate(dataloader):
             utts = batch['key']
-            targets = batch['label']
+            targets = batch['label'] if len(batch['label'].shape) else batch['label'].unsqueeze(0)
             features = batch['feat']
 
             cur_iter = (epoch - 1) * loader_size + i


### PR DESCRIPTION
The following error occurs when batch_size = 1 or drop_last = False: ValueError: Expected input batch_size (1) to match target batch_size (0).