### PR TITLE
[processor.py] fix bugs when get_random_chunk input is numpy.narray

### DIFF
--- a/wespeaker/dataset/processor.py
+++ b/wespeaker/dataset/processor.py
@@ -289,7 +289,7 @@ def get_random_chunk(data, chunk_len):
         repeat_shape = repeat_factor if len(data_shape) == 1 else (repeat_factor, 1)
         if type(data) == torch.Tensor:
             data = data.repeat(repeat_shape)
-        else: # np.array
+        else:  # np.array
             data = np.tile(data, repeat_shape)
         data = data[:chunk_len]
 

--- a/wespeaker/dataset/processor.py
+++ b/wespeaker/dataset/processor.py
@@ -287,7 +287,10 @@ def get_random_chunk(data, chunk_len):
         # padding
         repeat_factor = chunk_len // data_len + 1
         repeat_shape = repeat_factor if len(data_shape) == 1 else (repeat_factor, 1)
-        data = data.repeat(repeat_shape)
+        if type(data) == torch.Tensor:
+            data = data.repeat(repeat_shape)
+        else: # np.array
+            data = np.tile(data, repeat_shape)
         data = data[:chunk_len]
 
     return data


### PR DESCRIPTION
function `get_random_chunk` is called in `add_reverb_noise` with numpy.narray as input(`data`). However, `Tensor.repeat` is different from `numpy.repeat`. Maybe `numpy.tile` is what you want.