### PR TITLE
fix windows build error

### DIFF
--- a/runtime/core/speaker/onnx_speaker_model.cc
+++ b/runtime/core/speaker/onnx_speaker_model.cc
@@ -43,10 +43,10 @@ OnnxSpeakerModel::OnnxSpeakerModel(const std::string& model_path) {
   // 1. Load sessions
   #ifdef _MSC_VER
   speaker_session_ = std::make_shared<Ort::Session>(
-                     env_, ToWString(model_path).c_str(),session_options_);
+                     env_, ToWString(model_path).c_str(), session_options_);
   #else
   speaker_session_ = std::make_shared<Ort::Session>(
-                     env_, model_path.c_str(),session_options_);
+                     env_, model_path.c_str(), session_options_);
   #endif
   // 2. Model info
   Ort::AllocatorWithDefaultOptions allocator;

--- a/runtime/core/speaker/onnx_speaker_model.cc
+++ b/runtime/core/speaker/onnx_speaker_model.cc
@@ -42,11 +42,11 @@ OnnxSpeakerModel::OnnxSpeakerModel(const std::string& model_path) {
       GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
   // 1. Load sessions
   #ifdef _MSC_VER
-  speaker_session_ = std::make_shared<Ort::Session>(env_, ToWString(model_path).c_str(),
-                                                      session_options_);
-  #else                                                    
-  speaker_session_ = std::make_shared<Ort::Session>(env_, model_path.c_str(),
-                                                      session_options_);
+  speaker_session_ = std::make_shared<Ort::Session>(
+                     env_, ToWString(model_path).c_str(),session_options_);
+  #else
+  speaker_session_ = std::make_shared<Ort::Session>(
+                     env_, model_path.c_str(),session_options_);
   #endif
   // 2. Model info
   Ort::AllocatorWithDefaultOptions allocator;

--- a/runtime/core/speaker/onnx_speaker_model.cc
+++ b/runtime/core/speaker/onnx_speaker_model.cc
@@ -18,7 +18,7 @@
 
 #include "speaker/onnx_speaker_model.h"
 #include "glog/logging.h"
-
+#include "utils/utils.h"
 
 namespace wespeaker {
 
@@ -41,8 +41,13 @@ OnnxSpeakerModel::OnnxSpeakerModel(const std::string& model_path) {
   session_options_.SetGraphOptimizationLevel(
       GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
   // 1. Load sessions
+  #ifdef _MSC_VER
+  speaker_session_ = std::make_shared<Ort::Session>(env_, ToWString(model_path).c_str(),
+                                                      session_options_);
+  #else                                                    
   speaker_session_ = std::make_shared<Ort::Session>(env_, model_path.c_str(),
                                                       session_options_);
+  #endif
   // 2. Model info
   Ort::AllocatorWithDefaultOptions allocator;
   // 2.1. input info

--- a/runtime/core/speaker/speaker_engine.cc
+++ b/runtime/core/speaker/speaker_engine.cc
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
+#include <numeric>
 #include "speaker/speaker_engine.h"
 
 

--- a/runtime/core/utils/utils.cc
+++ b/runtime/core/utils/utils.cc
@@ -85,4 +85,16 @@ void SplitStringToVector(const std::string& full, const char* delim,
   }
 }
 
+#ifdef _MSC_VER
+std::wstring ToWString(const std::string& str) {
+  unsigned len = str.size() * 2;
+  setlocale(LC_CTYPE, "");
+  wchar_t* p = new wchar_t[len];
+  mbstowcs(p, str.c_str(), len);
+  std::wstring wstr(p);
+  delete[] p;
+  return wstr;
+}
+#endif
+
 }  // namespace wespeaker

--- a/runtime/core/utils/utils.h
+++ b/runtime/core/utils/utils.h
@@ -35,6 +35,10 @@ void SplitStringToVector(const std::string& full, const char* delim,
                          bool omit_empty_strings,
                          std::vector<std::string>* out);
 
+#ifdef _MSC_VER
+std::wstring ToWString(const std::string& str);
+#endif
+
 }  // namespace wespeaker
 
 #endif  // UTILS_UTILS_H_


### PR DESCRIPTION
目前windows 编译有2个错误：
1.  SpeakerEngine::CosineSimilarity 这个函数中 使用std::inner_product 错误，windows 上没有引用正确的头文件，[inner_product](https://en.cppreference.com/w/cpp/algorithm/inner_product)  正确的头文件是` #include <numeric>`
2. windows 上 onnxruntime  创建 Ort::Session 的参数错误，对应到如下代码：
```
    speaker_session_ = std::make_shared<Ort::Session>(env_, model_path.c_str(),
                                                      session_options_);
```
按照 https://github.com/wenet-e2e/wenet/blob/a7931ac212c4f28112874ca80cde3588ffedda4e/runtime/core/decoder/onnx_asr_model.cc#L86  这里修改 增加了  ToWString 转换函数