### PR TITLE
model.recognize 方法中 best_score 需要小于 score

### DIFF
--- a/wespeaker/cli/speaker.py
+++ b/wespeaker/cli/speaker.py
@@ -129,11 +129,11 @@ class Speaker:
         best_name = ''
         for name, e in self.table.items():
             score = self.cosine_similarity(q, e)
-            if best_score > score:
+            if best_score < score:
                 best_score = score
                 best_name = name
         result = {}
-        result['name'] = name
+        result['name'] = best_name
         result['confidence'] = best_score
         return result
 


### PR DESCRIPTION
bug fix
model.recognize 方法中 best_score 需要小于 score
将 best_name 最终赋值给 result['name']  
#236 