### PR TITLE
[runtime] fix bug in PcmReader where data may be out of bounds

### DIFF
--- a/runtime/core/frontend/wav.h
+++ b/runtime/core/frontend/wav.h
@@ -17,6 +17,7 @@
 #define FRONTEND_WAV_H_
 
 #include <assert.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -210,7 +211,9 @@ class PcmReader : public AudioReader {
     fseek(fp, 0, SEEK_END);
     int data_size = ftell(fp);
     fseek(fp, 0, SEEK_SET);
-    num_sample_ = data_size / sizeof(int16_t);
+    // If data_size is odd, apply for (data_size + 1) bytes of space.
+    // If data_size is even, apply for data_size bytes of space.
+    num_sample_ = ceil(1.0 * data_size / sizeof(int16_t));
     data_.resize(num_sample_);
     fread(&data_[0], data_size, 1, fp);
     fclose(fp);


### PR DESCRIPTION
bug描述：对于正常的PCM数据，读取的二进制数据大小应该是偶数。但对于异常数据，读取的二进制数据大小是奇数，那么就是发生越界问题。