### PR TITLE
[fix] cannot seek vector iterator after end

### DIFF
--- a/runtime/core/speaker/speaker_engine.cc
+++ b/runtime/core/speaker/speaker_engine.cc
@@ -120,11 +120,11 @@ void SpeakerEngine::ExtractFeature(
           }
           chunk_feat.insert(
               chunk_feat.end(), chunk_feat.begin(),
-              chunk_feat.begin() + num_chunk_frames_ - chunk_feat.size());
+              chunk_feat.begin() + (num_chunk_frames_ - chunk_feat.size()));
         } else {
           chunk_feat.insert(chunk_feat.end(), (*chunks_feat)[0].begin(),
-                            (*chunks_feat)[0].begin() + num_chunk_frames_ -
-                                chunk_feat.size());
+                            (*chunks_feat)[0].begin() + (num_chunk_frames_ -
+                                chunk_feat.size()));
         }
         CHECK_EQ(chunk_feat.size(), num_chunk_frames_);
         chunks_feat->emplace_back(chunk_feat);


### PR DESCRIPTION
当我在windows下用MSVC编译，在运行时出现和 #205 一样的问题。经过排查发现 `chunk_feat` 长度为178 , 而`num_chunk_frames_` (使用默认参数)为198. 所有vector索引越界了。

另外我使用 #205 问题中的音频是没有问题的，我是使用自己的音频(不到1s)。