### PR TITLE
[fix] fix tarfile bug in processor.py

### DIFF
--- a/wespeaker/dataset/processor.py
+++ b/wespeaker/dataset/processor.py
@@ -77,7 +77,7 @@ def tar_file_and_group(data):
     """
     for sample in data:
         assert 'stream' in sample
-        stream = tarfile.open(fileobj=sample['stream'], mode="r|*")
+        stream = tarfile.open(fileobj=sample['stream'], mode="r:*")
         prev_prefix = None
         example = {}
         valid = True


### PR DESCRIPTION
`tarfile` may have error `AttributeError: '_Stream' object has no attribute 'seekable'`. This updated syntax will fix this error.