### PR TITLE
Exp with multiple log files 

### DIFF
--- a/wespeaker/bin/train.py
+++ b/wespeaker/bin/train.py
@@ -32,10 +32,10 @@ from wespeaker.models.speaker_model import get_speaker_model
 from wespeaker.utils.checkpoint import load_checkpoint, save_checkpoint
 from wespeaker.utils.executor import run_epoch
 from wespeaker.utils.file_utils import read_table
-from wespeaker.utils.utils import get_logger, parse_config_or_kwargs, set_seed, \
+from wespeaker.utils.utils import parse_config_or_kwargs, set_seed, \
     spk2id, setup_logger
 
-MAX_NUM_log_files=100
+MAX_NUM_log_files = 100
 
 def train(config='conf/config.yaml', **kwargs):
     """Trains a model on the given features and spk labels.
@@ -53,7 +53,7 @@ def train(config='conf/config.yaml', **kwargs):
     gpu = int(configs['gpus'][local_rank])
     torch.cuda.set_device(gpu)
     dist.init_process_group(backend='nccl')
-    
+
     model_dir = os.path.join(configs['exp_dir'], "models")
     dist.barrier(device_ids=[gpu])  # let the rank 0 mkdir first
 

--- a/wespeaker/bin/train.py
+++ b/wespeaker/bin/train.py
@@ -53,6 +53,7 @@ def train(config='conf/config.yaml', **kwargs):
     gpu = int(configs['gpus'][local_rank])
     torch.cuda.set_device(gpu)
     dist.init_process_group(backend='nccl')
+    
     model_dir = os.path.join(configs['exp_dir'], "models")
     dist.barrier(device_ids=[gpu])  # let the rank 0 mkdir first
 

--- a/wespeaker/models/ecapa_tdnn.py
+++ b/wespeaker/models/ecapa_tdnn.py
@@ -217,20 +217,21 @@ class ECAPA_TDNN(nn.Module):
         out = torch.cat([out2, out3, out4], dim=1)
         out = self.conv(out)
 
-        return out
+        return out, out4
 
     def get_frame_level_feat(self, x):
         # for outer interface
-        out = self._get_frame_level_feat(x).permute(0, 2, 1)
+        out = self._get_frame_level_feat(x)[0].permute(0, 2, 1)
         return out  # (B, T, D)
 
     def forward(self, x):
-        out = F.relu(self._get_frame_level_feat(x))
+        out, out4 = self._get_frame_level_feat(x)
+        out = F.relu(out)
         out = self.bn(self.pool(out))
         out = self.linear(out)
         if self.emb_bn:
             out = self.bn2(out)
-        return out
+        return out4, out
 
 
 def ECAPA_TDNN_c1024(feat_dim, embed_dim, pooling_func='ASTP', emb_bn=False):

--- a/wespeaker/utils/utils.py
+++ b/wespeaker/utils/utils.py
@@ -19,7 +19,6 @@ import random
 import numpy as np
 import torch
 import yaml
-from distutils.util import strtobool
 from pathlib import Path
 import shutil
 

--- a/wespeaker/utils/utils.py
+++ b/wespeaker/utils/utils.py
@@ -22,8 +22,6 @@ import yaml
 from distutils.util import strtobool
 from pathlib import Path
 import shutil
-import torch.distributed as dist
-
 
 
 


### PR DESCRIPTION
Problem:
When attempting to train the same model in the same exp_dir, it is necessary to first delete the contents of the exp_dir/models/ directory. Otherwise, the training process will fail.

New Function:
* The existing train.log will be renamed to train.1.log, and a new train.log will be generated in the same exp_dir.
* If training is resumed in the same exp_dir with checkpoint=None, the checkpoint will overwrite the previous one.
* If training is resumed with a non-null checkpoint (checkpoint != None), the training will continue from the specified checkpoint.