### PR TITLE
Avoid error when attempting to diarize audio with no speech

### DIFF
--- a/wespeaker/cli/speaker.py
+++ b/wespeaker/cli/speaker.py
@@ -223,7 +223,8 @@ class Speaker:
         vad_segments = get_speech_timestamps(wav,
                                              self.vad,
                                              return_seconds=True)
-
+        if not vad_segments:
+            return []
         # 2. extact fbanks
         subsegs, subseg_fbanks = [], []
         window_fs = int(self.diar_window_secs * 1000) // self.diar_frame_shift


### PR DESCRIPTION
By returning an empty list in cli.speaker.Speaker.diarize if VAD returns an empty list. Otherwise a call results in this error:
```
  File "/usr/local/lib/python3.9/site-packages/wespeaker/cli/speaker.py", line 252, in diarize
    embeddings = self.extract_embedding_feats(subseg_fbanks,
  File "/usr/local/lib/python3.9/site-packages/wespeaker/cli/speaker.py", line 111, in extract_embedding_feats
    fbanks_array = np.stack(fbanks)
  File "/usr/local/lib/python3.9/site-packages/numpy/core/shape_base.py", line 445, in stack
    raise ValueError('need at least one array to stack')
ValueError: need at least one array to stack
```