### PR TITLE
Add support for custom directory for pre-trained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ similarity = model.compute_similarity('audio1.wav', 'audio2.wav')
 diar_result = model.diarize('audio.wav')
 ```
 
+You can set the environment variable `WESPEAKER_HOME` to specify the path of downloaded pre-trained models. By default it will be `$HOME/.wespeaker`.
+
 Please refer to [python usage](docs/python_package.md) for more command line and python programming usage.
 
 ### Install for development & deployment

--- a/wespeaker/cli/hub.py
+++ b/wespeaker/cli/hub.py
@@ -103,7 +103,8 @@ class Hub(object):
             print("ERROR: Unsupported lang {} !!!".format(lang))
             sys.exit(1)
         model = Hub.Assets[lang]
-        model_dir = os.path.join(Path.home(), ".wespeaker", lang)
+        wespeaker_home = os.environ.get("WESPEAKER_HOME", Path.home() / ".wespeaker")
+        model_dir = os.path.join(wespeaker_home, lang)
         if not os.path.exists(model_dir):
             os.makedirs(model_dir)
         if set(["avg_model.pt", "config.yaml"]).issubset(


### PR DESCRIPTION
As [the issue](https://github.com/wenet-e2e/wespeaker/issues/438) demonstrates, I add the support for customizing the home directory for saving pre-trained models. It is specified by `WESPEAKER_HOME` environment variable and is `~/.wespeaker` by default. 

This is usable when we often mount a filesystem on clusters while the original home directory is in the docker container. Exposing this interface facilitates saving models on permanent storage (mounted filesystems).