### PR TITLE
fix: resolve bugs in WarmupLR_withStepDecay and train config

### DIFF
--- a/examples/voxceleb/v2/conf/w2vbert_s1_lora.yaml
+++ b/examples/voxceleb/v2/conf/w2vbert_s1_lora.yaml
@@ -48,6 +48,14 @@ dataset_args:
       lora_dropout: 0.0
       bias: "none"
   # Note: w2vbert frontend handles feature extraction, no fbank_args needed
+  cmvn: False
+  spec_aug: False
+  spec_aug_args:
+    num_t_mask: 1
+    num_f_mask: 1
+    max_t: 10
+    max_f: 8
+    prob: 0.6
 
 # Model definition
 model: W2VBert_Adapter_MFA  # The new speaker model class

--- a/examples/voxceleb/v2/conf/w2vbert_s2_ft.yaml
+++ b/examples/voxceleb/v2/conf/w2vbert_s2_ft.yaml
@@ -42,6 +42,14 @@ dataset_args:
     frozen: False  # Unfreeze the base W2V-BERT model
     use_lora: False  # No LoRA in this stage
     lora_config_args: null
+  cmvn: False
+  spec_aug: False
+  spec_aug_args:
+    num_t_mask: 1
+    num_f_mask: 1
+    max_t: 10
+    max_f: 8
+    prob: 0.6
 
 # Model definition (load S1 model, unfreeze frontend, remove LoRA)
 model: W2VBert_Adapter_MFA

--- a/examples/voxceleb/v2/conf/w2vbert_s3_lmft.yaml
+++ b/examples/voxceleb/v2/conf/w2vbert_s3_lmft.yaml
@@ -43,6 +43,14 @@ dataset_args:
     frozen: False  # Keep unfrozen
     use_lora: False
     lora_config_args: null
+  cmvn: False
+  spec_aug: False
+  spec_aug_args:
+    num_t_mask: 1
+    num_f_mask: 1
+    max_t: 10
+    max_f: 8
+    prob: 0.6
 
 # Model definition (load S2 model)
 model: W2VBert_Adapter_MFA

--- a/wespeaker/bin/extract.py
+++ b/wespeaker/bin/extract.py
@@ -103,7 +103,7 @@ def extract(config='conf/config.yaml', **kwargs):
                     features, _ = model.frontend(wavs, wavs_len)
 
                 # apply cmvn
-                if test_conf.get('cmvn', False):
+                if test_conf.get('cmvn', True):
                     features = apply_cmvn(features,
                                           **test_conf.get('cmvn_args', {}))
                 # spec augmentation

--- a/wespeaker/utils/executor.py
+++ b/wespeaker/utils/executor.py
@@ -49,7 +49,7 @@ def run_epoch(dataloader, epoch_iter, model, criterion, optimizer, scheduler,
 
         with torch.cuda.amp.autocast(enabled=configs['enable_amp']):
             # apply cmvn
-            if configs['dataset_args'].get('cmvn', False):
+            if configs['dataset_args'].get('cmvn', True):
                 features = apply_cmvn(
                     features, **configs['dataset_args'].get('cmvn_args', {}))
             # spec augmentation


### PR DESCRIPTION
### Description
This PR fixes two issues in the training configuration and scheduler:

1. **WarmupLR_withStepDecay**:
   - Fixed a bug where `warmup_step` was treated as iterations instead of epochs. It is now correctly multiplied by `epoch_iter`.

2. **Config Compatibility**:
   - Modified `train.py` to use `.pop('initial_lr')`. This prevents `KeyError`/`TypeError` when `initial_lr` is not defined in `scheduler_args` (e.g., in W2V tasks), while maintaining compatibility for other tasks.

3. **CMVN Default**:
   - Fixed the default value logic for CMVN in `executor.py`.